### PR TITLE
Bindle push compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,12 +311,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -324,6 +340,17 @@ name = "futures-core"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -344,6 +371,50 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+
+[[package]]
+name = "futures-task"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+
+[[package]]
+name = "futures-util"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -407,6 +478,7 @@ dependencies = [
  "async-std",
  "chrono",
  "clap",
+ "futures",
  "glob",
  "mime_guess",
  "semver",
@@ -606,6 +678,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 async-std = { version = "1.9.0", features = ["attributes"] }
 chrono = "0.4"
 clap = { version = "3.0.0-beta.2" }
+futures = "0.3.14"
 glob = "0.3.0"
 mime_guess = { version = "2.0" }
 semver = { version = "0.11", features = ["serde"] }

--- a/src/bindle_writer.rs
+++ b/src/bindle_writer.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use crate::invoice::Invoice;
+use sha2::{Digest, Sha256};
+
+use crate::invoice::{Invoice, Parcel};
 
 pub struct BindleWriter {
     source_base_path: PathBuf,
@@ -17,6 +19,48 @@ impl BindleWriter {
 
     pub async fn write(&self, invoice: &Invoice) -> anyhow::Result<()> {
         // This is very similar to bindle::StandaloneWrite::write but... not quite the same
-        todo!("oh no")
+        let bindle_id_hash = sha(&invoice.bindle.name, &invoice.bindle.version);
+        let bindle_dir = self.dest_base_path.join(bindle_id_hash);
+        let parcels_dir = bindle_dir.join("parcels");
+        async_std::fs::create_dir_all(&parcels_dir).await?;
+
+        self.write_invoice_file(invoice, &bindle_dir).await?;
+        self.write_parcel_files(invoice, &parcels_dir).await?;
+        Ok(())
     }
+
+    async fn write_invoice_file(&self, invoice: &Invoice, bindle_dir: &PathBuf) -> anyhow::Result<()> {
+        let invoice_text = toml::to_string_pretty(&invoice)?;
+        let invoice_file = bindle_dir.join("invoice.toml");
+        async_std::fs::write(&invoice_file, &invoice_text).await?;
+        Ok(())
+    }
+
+    async fn write_parcel_files(&self, invoice: &Invoice, parcels_dir: &PathBuf) -> anyhow::Result<()> {
+        let parcels = match &invoice.parcel {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let parcel_writes = parcels.iter().map(|parcel| self.write_one_parcel(parcels_dir, &parcel));
+        futures::future::join_all(parcel_writes).await.into_iter().collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(())
+    }
+
+    async fn write_one_parcel(&self, parcels_dir: &PathBuf, parcel: &Parcel) -> anyhow::Result<()> {
+        let source_file = self.source_base_path.join(&parcel.label.name);
+        let hash = &parcel.label.sha256;
+        let dest_file = parcels_dir.join(format!("{}.dat", hash));
+        async_std::fs::copy(&source_file, &dest_file).await?;
+        Ok(())
+    }
+}
+
+fn sha(name: &str, version: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(name);
+    hasher.update("/");
+    hasher.update(version);
+    let result = hasher.finalize();
+    format!("{:x}", result)
 }


### PR DESCRIPTION
The `bindle push` command requires a specific on-disk layout of the invoice and parcels.  This PR writes and copies files to conform to that layout so they can be pushed with no further activity.

We could make this an option, or e.g. have separate `expand` and `prepare` sub-commands.  But I think this, although perhaps not optimal, will suffice for the initial end-to-end Hippo demo scenario.