### PR TITLE
Output format for programmatic use

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod hippofacts;
 
 const ARG_HIPPOFACTS: &str = "hippofacts_path";
 const ARG_STAGING_DIR: &str = "output_dir";
+const ARG_OUTPUT: &str = "output_format";
 const ARG_VERSIONING: &str = "versioning";
 const ARG_SERVER_URL: &str = "bindle_server";
 const ARG_PREPARE_ONLY: &str = "prepare";
@@ -29,8 +30,8 @@ async fn main() -> anyhow::Result<()> {
             clap::Arg::new(ARG_STAGING_DIR)
                 .required(false)
                 .takes_value(true)
-                .short('o')
-                .long("output")
+                .short('d')
+                .long("dir")
                 .about("The path to output the artifacts to (required with --prepare, otherwise uses a temporary directory)"),
         )
         .arg(
@@ -41,6 +42,15 @@ async fn main() -> anyhow::Result<()> {
                 .short('v')
                 .long("invoice-version")
                 .about("How to version the generated invoice"),
+        )
+        .arg(
+            clap::Arg::new(ARG_OUTPUT)
+                .possible_values(&["id", "message", "none"])
+                .default_value("message")
+                .required(false)
+                .short('o')
+                .long("output")
+                .about("What to print on success"),
         )
         .arg(
             clap::Arg::new(ARG_SERVER_URL)
@@ -66,6 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let staging_dir_arg = args
         .value_of(ARG_STAGING_DIR);
     let versioning_arg = args.value_of(ARG_VERSIONING).unwrap();
+    let output_format_arg = args.value_of(ARG_OUTPUT).unwrap();
     let push_to =
         if args.is_present(ARG_PREPARE_ONLY) {
             None
@@ -88,14 +99,16 @@ async fn main() -> anyhow::Result<()> {
         None => std::env::temp_dir().join("hippo-staging"),  // TODO: make unpredictable?
     };
     let invoice_versioning = InvoiceVersioning::parse(versioning_arg);
+    let output_format = OutputFormat::parse(output_format_arg);
 
-    run(&source, &destination, invoice_versioning, push_to).await
+    run(&source, &destination, invoice_versioning, output_format, push_to).await
 }
 
 async fn run(
     source: impl AsRef<std::path::Path>,
     destination: impl AsRef<std::path::Path>,
     invoice_versioning: InvoiceVersioning,
+    output_format: OutputFormat,
     push_to: Option<String>,
 ) -> anyhow::Result<()> {
     let source_dir = source
@@ -114,13 +127,40 @@ async fn run(
     let invoice = expander::expand(&spec, &expansion_context)?;
     writer.write(&invoice).await?;
 
-    if let Some(url) = push_to {
+    if let Some(url) = &push_to {
         bindle_pusher::push_all(&destination, &invoice.bindle.id, &url).await?;
-        println!("pushed: {}", &invoice.bindle.id);
-    } else {
-        println!("id:      {}", &invoice.bindle.id);
-        println!("command: bindle push -p {} {}", &destination.as_ref().canonicalize()?.to_string_lossy(), &invoice.bindle.id);
+    }
+
+    match output_format {
+        OutputFormat::None => (),
+        OutputFormat::Id => println!("{}", &invoice.bindle.id),
+        OutputFormat::Message => {
+            if push_to.is_some() {
+                println!("pushed: {}", &invoice.bindle.id);
+            } else {
+                println!("id:      {}", &invoice.bindle.id);
+                println!("command: bindle push -p {} {}", &destination.as_ref().canonicalize()?.to_string_lossy(), &invoice.bindle.id);
+            }
+        }
     }
 
     Ok(())
+}
+
+enum OutputFormat {
+    None,
+    Id,
+    Message,
+}
+
+impl OutputFormat {
+    pub fn parse(text: &str) -> Self {
+        if text == "none" {
+            OutputFormat::None
+        } else if text == "id" {
+            OutputFormat::Id
+        } else {
+            OutputFormat::Message
+        }
+    }
 }


### PR DESCRIPTION
For programmatic use, it is sometimes useful to be able to just get the ID of the generated bindle, without any messy text explaining "this is the ID, puny fleshling."  So, here we are.