### PR TITLE
Display path in normal way on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2641c4a7c0c4101df53ea572bffdc561c146f6c2eb09e4df02bc4811e3feeb4"
+
+[[package]]
 name = "ed25519"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +508,7 @@ dependencies = [
  "bindle",
  "chrono",
  "clap",
+ "dunce",
  "futures",
  "glob",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 bindle = { version = "0.3.1", default-features = false, features = ["client"] }
 chrono = "0.4"
 clap = { version = "3.0.0-beta.2" }
+dunce = "1.0"
 futures = "0.3.14"
 glob = "0.3.0"
 mime_guess = { version = "2.0" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn run(
                 println!("pushed: {}", &invoice.bindle.id);
             } else {
                 println!("id:      {}", &invoice.bindle.id);
-                println!("command: bindle push -p {} {}", &destination.as_ref().canonicalize()?.to_string_lossy(), &invoice.bindle.id);
+                println!("command: bindle push -p {} {}", dunce::canonicalize(&destination)?.to_string_lossy(), &invoice.bindle.id);
             }
         }
     }


### PR DESCRIPTION
Previously if you did a `prepare` it was printing the path as `\\?\C:\...` instead of `C:\...`.  No longer.