### PR TITLE
Notify new revisions to Hippo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hippo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "hippofactory"
 version = "0.3.0"
 dependencies = [
@@ -517,6 +535,7 @@ dependencies = [
  "dunce",
  "futures",
  "glob",
+ "hippo",
  "itertools",
  "mime_guess",
  "semver",
@@ -1515,8 +1534,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1602,6 +1634,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
 [[package]]
 name = "hippo"
 version = "0.1.0"
+source = "git+https://github.com/deislabs/hippo-client-rust?branch=main#627c35b4a22860a016e9d4b8164036356cffe44a"
 dependencies = [
  "anyhow",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "3.0.0-beta.2" }
 dunce = "1.0"
 futures = "0.3.14"
 glob = "0.3.0"
+hippo = { path = "../hippo-client-rust" }
 itertools = "0.10.0"
 mime_guess = { version = "2.0" }
 semver = { version = "0.11", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "3.0.0-beta.2" }
 dunce = "1.0"
 futures = "0.3.14"
 glob = "0.3.0"
-hippo = { path = "../hippo-client-rust" }
+hippo = { git = "https://github.com/deislabs/hippo-client-rust", branch = "main" }
 itertools = "0.10.0"
 mime_guess = { version = "2.0" }
 semver = { version = "0.11", features = ["serde"] }

--- a/src/hippo_notifier.rs
+++ b/src/hippo_notifier.rs
@@ -1,6 +1,12 @@
-pub async fn register(bindle_id: &bindle::Id, hippo_url: &str) -> anyhow::Result<()> {
+pub struct ConnectionInfo {
+    pub url: String,
+    pub username: String,
+    pub password: String,
+}
+
+pub async fn register(bindle_id: &bindle::Id, conn_info: &ConnectionInfo) -> anyhow::Result<()> {
     // TODO: username and password
-    let hippo_client = hippo::Client::new_from_login(hippo_url, "admin", "Passw0rd!").await?;
+    let hippo_client = hippo::Client::new_from_login(&conn_info.url, &conn_info.username, &conn_info.password).await?;
     hippo_client
         .register_revision_by_storage_id(bindle_id.name(), &bindle_id.version_string())
         .await?;

--- a/src/hippo_notifier.rs
+++ b/src/hippo_notifier.rs
@@ -1,0 +1,8 @@
+pub async fn register(bindle_id: &bindle::Id, hippo_url: &str) -> anyhow::Result<()> {
+    // TODO: username and password
+    let hippo_client = hippo::Client::new_from_login(hippo_url, "admin", "Passw0rd!").await?;
+    hippo_client
+        .register_revision_by_storage_id(bindle_id.name(), &bindle_id.version_string())
+        .await?;
+    Ok(())
+}

--- a/src/hippo_notifier.rs
+++ b/src/hippo_notifier.rs
@@ -5,7 +5,6 @@ pub struct ConnectionInfo {
 }
 
 pub async fn register(bindle_id: &bindle::Id, conn_info: &ConnectionInfo) -> anyhow::Result<()> {
-    // TODO: username and password
     let hippo_client = hippo::Client::new_from_login(&conn_info.url, &conn_info.username, &conn_info.password).await?;
     hippo_client
         .register_revision_by_storage_id(bindle_id.name(), &bindle_id.version_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use hippofacts::HippoFacts;
 mod bindle_pusher;
 mod bindle_writer;
 mod expander;
+mod hippo_notifier;
 mod hippofacts;
 
 const ARG_HIPPOFACTS: &str = "hippofacts_path";
@@ -156,15 +157,7 @@ async fn run(
     if let Some(url) = &push_to {
         bindle_pusher::push_all(&destination, &invoice.bindle.id, &url).await?;
         if let Some(hippo_url) = &notify_to {
-            // TODO: username and password
-            let hippo_client =
-                hippo::Client::new_from_login(hippo_url, "admin", "Passw0rd!").await?;
-            hippo_client
-                .register_revision_by_storage_id(
-                    &invoice.bindle.id.name(),
-                    &invoice.bindle.id.version_string(),
-                )
-                .await?;
+            hippo_notifier::register(&invoice.bindle.id, &hippo_url).await?;
         }
     }
 


### PR DESCRIPTION
When we push a new revision, we should (by default) also notify Hippo.

This changes the command line as follows:

* Adds parameters for Hippo URL, user name and password
* Removes `--prepare` in favour of `--action` which can be `prepare` (assemble files only), `bindle` (also push to Bindle) or `all` (also notify to Hippo).  The default is `all` because in a dev environment you want Hippo to update.

NOTE: There isn't yet a Hippo crate so this currently requires the Hippo client from an adjacent source directory.  That's why it doesn't compile.