### PR TITLE
Rename CLI to 'hippo'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "hippofactory"
+name = "hippo"
 version = "0.5.0"
 dependencies = [
  "anyhow",
@@ -517,7 +517,7 @@ dependencies = [
  "dunce",
  "futures",
  "glob",
- "hippo",
+ "hippo 0.1.0",
  "itertools",
  "mime_guess",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hippofactory"
+name = "hippo"
 version = "0.5.0"
 authors = ["Ivan Towlson <itowlson@microsoft.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# hippofactory
+# Hippo Client
 
-`hippofactory` is an **experimental** client for [Bindle](https://github.com/deislabs/bindle).
+`hippo` is an **experimental** client for the [Hippo PaaS](https://github.com/deislabs/hippo) and [Bindle](https://github.com/deislabs/bindle).
 
-The `hippofactory` tool processes an application's `HIPPOFACTS` (Hippo
+The `hippo` tool processes an application's `HIPPOFACTS` (Hippo
 artifacts) file and generates a bindle that it can either push directly
 or can later be uploaded using `bindle push`.
 
@@ -184,7 +184,7 @@ name = 'bin/cassowary.wasm-files'
 name = 'bin/kea.wasm-files'
 ```
 
-`hippofactory` does not currently support Bindle's `parcel.label.feature`
+`hippo` does not currently support Bindle's `parcel.label.feature`
 or `signature` features.  It does not yet support push options other than the server URL (e.g. auth).
 
 ### External handlers
@@ -209,7 +209,7 @@ route = "/images"
 files = ["birds/*.jpg"]
 ```
 
-Hippofactory will locate the specified `wagi_handler_id` in the given bindle, and create a
+The Hippo client will locate the specified `wagi_handler_id` in the given bindle, and create a
 parcel in your invoice that points to the same blob but with a `requires` condition for
 the handler group. It also creates parcels for any parcels that the handler `requires`
 in its original bindle.
@@ -232,10 +232,10 @@ files = ["cache/*.db"]
 there will be no application mapped to the resultant bindle. Pass `-a bindle` to
 push to the Bindle server but not register it with Hippo.
 
-## Running hippofactory
+## Running the Hippo Client
 
-As a developer you can run `hippofactory .` in your `HIPPOFACTS` directory to assemble all matching
-files and publish them as a bindle. In this mode, `hippofactory`:
+As a developer you can run `hippo .` in your `HIPPOFACTS` directory to assemble all matching
+files and publish them as a bindle. In this mode, `hippo`:
 
 * Mangles the version with a prerelease segment
 * Stages to a temporary directory

--- a/src/bindle_writer.rs
+++ b/src/bindle_writer.rs
@@ -61,7 +61,7 @@ impl BindleWriter {
     }
 
     async fn write_one_parcel(&self, parcels_dir: &PathBuf, parcel: &Parcel) -> anyhow::Result<()> {
-        if parcel.has_annotation("hippofactory_do_not_stage") {
+        if parcel.has_annotation("hippos_do_not_stage") {
             return Ok(());
         }
         let source_file = self.source_base_path.join(&parcel.label.name);

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -505,7 +505,7 @@ fn map_of(values: Vec<(&str, &str)>) -> BTreeMap<String, String> {
 
 fn annotation_do_not_stage_file() -> Option<AnnotationMap> {
     let mut annotations = AnnotationMap::new();
-    annotations.insert("hippofactory_do_not_stage".to_owned(), "true".to_owned());
+    annotations.insert("hippos_do_not_stage".to_owned(), "true".to_owned());
     Some(annotations)
 }
 

--- a/src/hippo_notifier.rs
+++ b/src/hippo_notifier.rs
@@ -9,7 +9,13 @@ pub async fn register(bindle_id: &bindle::Id, conn_info: &ConnectionInfo) -> any
     let options = hippo::ClientOptions {
         danger_accept_invalid_certs: conn_info.danger_accept_invalid_certs,
     };
-    let hippo_client = hippo::Client::new_with_options(&conn_info.url, &conn_info.username, &conn_info.password, options).await?;
+    let hippo_client = hippo::Client::new_with_options(
+        &conn_info.url,
+        &conn_info.username,
+        &conn_info.password,
+        options,
+    )
+    .await?;
     hippo_client
         .register_revision_by_storage_id(bindle_id.name(), &bindle_id.version_string())
         .await?;

--- a/src/hippofacts.rs
+++ b/src/hippofacts.rs
@@ -134,8 +134,13 @@ impl TryFrom<&RawHandler> for HippoFactsEntry {
     fn try_from(raw: &RawHandler) -> anyhow::Result<Self> {
         let handler_module = match (&raw.name, &raw.external) {
             (Some(name), None) => Ok(HandlerModule::File(name.clone())),
-            (None, Some(external_ref)) => Ok(HandlerModule::External(ExternalRef::try_from(external_ref)?)),
-            _ => Err(anyhow::anyhow!("Route '{}' must specify exactly one of 'name' and 'external'", raw.route)),
+            (None, Some(external_ref)) => Ok(HandlerModule::External(ExternalRef::try_from(
+                external_ref,
+            )?)),
+            _ => Err(anyhow::anyhow!(
+                "Route '{}' must specify exactly one of 'name' and 'external'",
+                raw.route
+            )),
         }?;
         let entry = match handler_module {
             HandlerModule::File(name) => Self::LocalHandler(LocalHandler {
@@ -202,7 +207,7 @@ fn no_handlers() -> anyhow::Error {
 #[cfg(test)]
 mod test {
     use super::*;
-    
+
     impl HippoFactsEntry {
         pub fn name(&self) -> Option<String> {
             match self {
@@ -211,7 +216,7 @@ mod test {
                 Self::Export(e) => Some(e.name.clone()),
             }
         }
-    
+
         pub fn route(&self) -> Option<String> {
             match self {
                 Self::LocalHandler(h) => Some(h.route.clone()),
@@ -219,7 +224,7 @@ mod test {
                 Self::Export(_) => None,
             }
         }
-    
+
         pub fn export_id(&self) -> Option<String> {
             match self {
                 Self::LocalHandler(_) => None,
@@ -228,7 +233,7 @@ mod test {
             }
         }
     }
-    
+
     #[test]
     fn test_can_read_hippo_facts() {
         let raw: RawHippoFacts = toml::from_str(


### PR DESCRIPTION
Per the conversation in #31 and on chat, this renames the project to "The Hippo Client" and the CLI to `hippo`.

One notable thing I did not change b/c I am not sure if there are any external dependencies on this naming convention:

```
src/bindle_writer.rs
64:        if parcel.has_annotation("hippofactory_do_not_stage") {

src/expander.rs
505:    annotations.insert("hippofactory_do_not_stage".to_owned(), "true".to_owned());
```

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>